### PR TITLE
Correct bug when ssh-port not set

### DIFF
--- a/bin/puppet-rundeck
+++ b/bin/puppet-rundeck
@@ -41,6 +41,11 @@ optparse = OptionParser.new do |opts|
     options[:username] = username
   end
 
+  options[:bind] = "0.0.0.0"
+  opts.on( '-b', '--bind IPADDRESS', 'The ipaddress to bind puppet-rundeck on') do |bind|
+    options[:bind] = bind
+  end
+
   options[:port] = 8144
   opts.on( '-p', '--port PORT', 'The port to run puppet-rundeck on') do |port|
     options[:port] = port
@@ -66,7 +71,7 @@ begin
   PuppetRundeck.username = options[:username]
   PuppetRundeck.ssh_port = options[:ssh_port]
   PuppetRundeck.configure
-  PuppetRundeck.run! :host => "localhost", :port => options[:port], :bind => '0.0.0.0'
+  PuppetRundeck.run! :host => "localhost", :port => options[:port], :bind => options[:port]
 rescue OptionParser::InvalidArgument, OptionParser::InvalidOption, OptionParser::MissingArgument
   puts $!.to_s
   puts optparse

--- a/lib/puppet-rundeck.rb
+++ b/lib/puppet-rundeck.rb
@@ -122,10 +122,9 @@ class PuppetRundeck < Sinatra::Base
           tags_string = [tags_string,facts_string].join(',')
         end
 
-        if PuppetRundeck.ssh_port.to_s == '22' then
-          hostname_port = ''
-        else
-          hostname_port = "\:#{PuppetRundeck.ssh_port.to_s}"
+        hostname = "#{facts["ipaddress"]}"
+        if PuppetRundeck.ssh_port.to_s != '22' then
+          hostname = "#{hostname}" ":" "#{PuppetRundeck.ssh_port.to_s}"
         end
 
       response_xml << <<-EOH
@@ -138,7 +137,7 @@ class PuppetRundeck < Sinatra::Base
       osVersion="#{xml_escape(facts["operatingsystemrelease"])}"
       tags="#{xml_escape(tags_string)}"
       username="#{xml_escape(targetusername)}"
-      hostname="#{xml_escape(facts["ipaddress"] + hostname_port)}"/>
+      hostname="#{xml_escape(hostname)}/>
 EOH
     end
     response_xml << "</project>"


### PR DESCRIPTION
ERROR Trace :

../bin/puppet-rundeck
[2013-11-26 09:53:06] INFO  WEBrick 1.3.1
[2013-11-26 09:53:06] INFO  ruby 1.8.7 (2011-06-30) [x86_64-linux]
== Sinatra/1.4.4 has taken the stage on 8144 for development with backup
from WEBrick
[2013-11-26 09:53:06] INFO  WEBrick::HTTPServer#start: pid=23803
port=8144
NoMethodError - undefined method `+' for nil:NilClass:

/usr/lib/ruby/gems/1.8/gems/puppet-rundeck-2013-0.0.12/lib/puppet-rundeck.rb:141:in
`respond'

/usr/lib/ruby/gems/1.8/gems/puppet-rundeck-2013-0.0.12/lib/puppet-rundeck.rb:71:in
`each'

/usr/lib/ruby/gems/1.8/gems/puppet-rundeck-2013-0.0.12/lib/puppet-rundeck.rb:71:in
`respond'

/usr/lib/ruby/gems/1.8/gems/puppet-rundeck-2013-0.0.12/lib/puppet-rundeck.rb:159:in
`GET /'
